### PR TITLE
[3.0.2] Fixed logrocket-react for production builds lacking _debugOwner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "logrocket-react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -20,16 +20,16 @@ export default function setupReact() {
           return;
         }
 
-        let currentElement = targetInst._debugOwner;
+        let currentElement = targetInst.return;
 
         const names = [];
-        while (currentElement) {
+        while (currentElement && currentElement.type) {
           const name = currentElement.type.displayName ||
             currentElement.type.name;
           if (name) {
             names.push(name);
           }
-          currentElement = currentElement._debugOwner;
+          currentElement = currentElement.return;
         }
 
         // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
This commit should be merged in a branch created for db185e6e2fbbb11e9d922c43f3b4ccfec887f18a and be released on the v3 branch. I made this fix to solve a problem we had using logrocket-react at https://wanderlog.com

When building React for production, the `targetInst` and `currentElement` variables lack the key `_debugOwner`, which only occurs in dev builds. Using `return` is another way to get the parent element though (see this nice [blog-post](https://medium.com/react-in-depth/the-how-and-why-on-reacts-usage-of-linked-list-in-fiber-67f1014d0eb7#1659)), and we should use that instead of `_debugOwner`.