### PR TITLE
React 17 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The LogRocket React plugin allows you to search for sessions in which the user c
 
 ## Guide for React versions
 
+### If using React 17
+`npm i --save logrocket-react@5`
+
 ### If using React 16.10
 `npm i --save logrocket-react@4`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "logrocket-react",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4734,6 +4734,11 @@
           "dev": true
         }
       }
+    },
+    "logrocket": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-2.1.3.tgz",
+      "integrity": "sha512-qrGyZON8EEpiFSWaiL2qM1LsgQ/ccivpMhrjGMLCrbG3uJ60YdRkgRR8bpuxkgMY3RMa8E7cpkvir0L0B/6yHg=="
     },
     "lolex": {
       "version": "2.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logrocket-react",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "React library for [LogRocket](https://logrocket.com/).",
   "main": "dist/index.js",
   "author": "Logrocket <support@logrocket.com> (https://logrocket.com/)",
@@ -17,9 +17,8 @@
     "build": "babel src --out-dir dist",
     "react:clean": "node_modules/.bin/rimraf node_modules/react node_modules/react-dom",
     "test": "node_modules/.bin/karma start",
-    "test:16.10": "npm run react:clean && npm i react@16.10 react-dom@16.10 --no-save && npm test",
-    "test:17.0": "npm run react:clean && npm i react@17.0 react-dom@17.0 --no-save && npm test",
-    "test:all": "DEV=true npm run test:16.10 && DEV=true npm run test:17.0",
+    "test:17": "npm run react:clean && npm i react@17.0 react-dom@17.0 --no-save && npm test",
+    "test:all": "DEV=true npm run test:17",
     "prepublish": "npm run build"
   },
   "devDependencies": {
@@ -60,7 +59,11 @@
     "webpack": "^1.5.1"
   },
   "peerDependencies": {
+    "logrocket": ">=2.0",
     "react": ">=17.0",
     "react-dom": ">=17.0"
+  },
+  "dependencies": {
+    "logrocket": "^2.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react:clean": "node_modules/.bin/rimraf node_modules/react node_modules/react-dom",
     "test": "node_modules/.bin/karma start",
     "test:16.10": "npm run react:clean && npm i react@16.10 react-dom@16.10 --no-save && npm test",
-    "test:all": "DEV=true npm run test:16.10",
+    "test:17.0": "npm run react:clean && npm i react@17.0 react-dom@17.0 --no-save && npm test",
+    "test:all": "DEV=true npm run test:16.10 && DEV=true npm run test:17.0",
     "prepublish": "npm run build"
   },
   "devDependencies": {
@@ -59,7 +60,7 @@
     "webpack": "^1.5.1"
   },
   "peerDependencies": {
-    "react": ">=16.10",
-    "react-dom": ">=16.10"
+    "react": ">=17.0",
+    "react-dom": ">=17.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import { __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from 'react-dom';
 let injectEventPluginsByName;
 // from https://github.com/facebook/react/blob/v16.5.1/packages/react-dom/src/client/ReactDOM.js#L750
 const secret = __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+console.log(secret);
 if (secret && secret.Events && secret.Events[3]) {
   injectEventPluginsByName = secret.Events[3];
 } else {
@@ -15,25 +17,32 @@ if (secret && secret.Events && secret.Events[3]) {
 export default function setupReact() {
   injectEventPluginsByName({
     ResponderEventPlugin: {
-      extractEvents: function logRocketReactEventHook(topLevelType, targetInst, fiberNode, nativeEvent) {
+      extractEvents: function logRocketReactEventHook(topLevelType, fiberNode, nativeEvent) {
         try {
           if (topLevelType !== 'click' || !fiberNode || !nativeEvent) {
             return;
           }
+
+          console.log('Args:', arguments);
 
           let currentElement = fiberNode;
 
           const names = [];
           while (currentElement) {
             var name = typeof currentElement.elementType === 'function' && currentElement.elementType.displayName;
+            if (currentElement.elementType) {
+              console.log(currentElement.elementType.displayName);
+            }
             if (name) {
               names.push(name);
             }
             currentElement = currentElement.return;
           }
           // eslint-disable-next-line no-param-reassign
+          console.log('Names:', names);
           nativeEvent.__lrName = names;
         } catch (error) {
+          console.error(error);
           console.error('logrocket-react caught an error while hooking into React. Please make sure you are using the correct version of logrocket-react for your version of react-dom.')
         }
       },

--- a/src/index.js
+++ b/src/index.js
@@ -1,51 +1,30 @@
 import { __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from 'react-dom';
 
 
-let injectEventPluginsByName;
-// from https://github.com/facebook/react/blob/v16.5.1/packages/react-dom/src/client/ReactDOM.js#L750
+let getInstanceFromNode;
 const secret = __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
-
-console.log(secret);
-if (secret && secret.Events && secret.Events[3]) {
-  injectEventPluginsByName = secret.Events[3];
+if (secret && secret.Events && secret.Events[0]) {
+  getInstanceFromNode = secret.Events[0];
 } else {
-  injectEventPluginsByName = () => {
-    console.warn('logrocket-react does not work with this version of React');
-  }
+  console.warn('logrocket-react does not work with this version of React');
 }
 
 export default function setupReact() {
-  injectEventPluginsByName({
-    ResponderEventPlugin: {
-      extractEvents: function logRocketReactEventHook(topLevelType, fiberNode, nativeEvent) {
-        try {
-          if (topLevelType !== 'click' || !fiberNode || !nativeEvent) {
-            return;
-          }
-
-          console.log('Args:', arguments);
-
-          let currentElement = fiberNode;
-
-          const names = [];
-          while (currentElement) {
-            var name = typeof currentElement.elementType === 'function' && currentElement.elementType.displayName;
-            if (currentElement.elementType) {
-              console.log(currentElement.elementType.displayName);
-            }
-            if (name) {
-              names.push(name);
-            }
-            currentElement = currentElement.return;
-          }
-          // eslint-disable-next-line no-param-reassign
-          console.log('Names:', names);
-          nativeEvent.__lrName = names;
-        } catch (error) {
-          console.error(error);
-          console.error('logrocket-react caught an error while hooking into React. Please make sure you are using the correct version of logrocket-react for your version of react-dom.')
+  const listener = event => {
+    try {
+      const fiberNode = getInstanceFromNode(event.target)
+      const names = [];
+      let currentElement = fiberNode;
+      while (currentElement) {
+        var name = typeof currentElement.elementType === 'function' && currentElement.elementType.displayName;
+        if (name) {
+          names.push(name);
         }
-      },
-    },
-  });
+        currentElement = currentElement.return;
+      }
+      event.__lrName = names;
+    } catch (err) {}
+  }
+
+  document.body.addEventListener('click', listener, { capture: true, passive: true });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,9 @@ export default function setupReact() {
         currentElement = currentElement.return;
       }
       event.__lrName = names;
-    } catch (err) {}
+    } catch (err) {
+      console.error('logrocket-react caught an error while hooking into React. Please make sure you are using the correct version of logrocket-react for your version of react-dom.')
+    }
   }
 
   document.body.addEventListener('click', listener, { capture: true, passive: true });

--- a/test/allTests.js
+++ b/test/allTests.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import setup from '../index';
+import setup from '../src/index';
 import React, { Component } from 'react';
 import { render } from 'react-dom';
 import { configure, mount } from 'enzyme';


### PR DESCRIPTION
Relevant ticket: https://github.com/LogRocket/logrocket-react/issues/23

This PR adds support for React 17. Since the event plugin hook was removed in React 17, we have to use a global body click handler and use the new secret function to get the React fiber node from the native browser event.